### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/greglaurent/result-ts/security/code-scanning/1](https://github.com/greglaurent/result-ts/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will specify the least privileges required for the workflow to function correctly. Based on the tasks performed in the workflow, the `contents: read` permission is sufficient, as the workflow only needs to read repository contents to perform its operations.

The `permissions` block will be added immediately after the `name` field at the top of the file. This ensures that the permissions apply to all jobs in the workflow unless overridden by a job-specific `permissions` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
