### PR TITLE
Update bundle size claims to match actual measurements

### DIFF
--- a/README.md
+++ b/README.md
@@ -757,9 +757,9 @@ Start with core essentials and add layers as needed:
 | ---------------------------------------------- | ---------------------- | ----------------- | ------------------------------------- |
 | **Core** (`result-ts`)                         | 11 essential functions | ~55-331 bytes     | Basic Result handling, safe execution |
 | **+ Data Transform** (`result-ts/iter`)        | +4 functions           | ~808 bytes total  | Value mapping, operation chaining     |
-| **+ Array Processing** (`result-ts/batch`)     | +10 functions          | ~965 bytes total  | Bulk operations, statistics           |
+| **+ Array Processing** (`result-ts/batch`)     | +10 functions          | ~1143 bytes total | Bulk operations, statistics           |
 | **+ Debugging** (`result-ts/utils`)            | +5 functions           | Similar to core   | Side effects, nullable conversion     |
-| **+ Advanced Patterns** (`result-ts/patterns`) | +7 functions           | ~1004 bytes total | Generators, applicative patterns      |
+| **+ Advanced Patterns** (`result-ts/patterns`) | +7 functions           | ~1282 bytes total | Generators, applicative patterns      |
 | **+ Validation** (`result-ts/schema`)          | +12 functions          | ~556 bytes\*      | Runtime validation with Zod           |
 
 \*Excludes Zod dependency (~13KB gzipped)
@@ -780,12 +780,12 @@ import { ok, err, handle, match } from "result-ts";
 import { ok, err, handle, match } from "result-ts";
 import { map, andThen } from "result-ts/iter";
 
-// Array processing - 965 bytes
+// Array processing - 1143 bytes
 import { ok, err, handle, match } from "result-ts";
 import { map, andThen } from "result-ts/iter";
 import { all, partition } from "result-ts/batch";
 
-// Advanced patterns - 1004 bytes
+// Advanced patterns - 1282 bytes
 import { ok, err, handle, match } from "result-ts";
 import { map, andThen } from "result-ts/iter";
 import { all, partition } from "result-ts/batch";
@@ -802,7 +802,7 @@ for unexpected errors (programming bugs, out-of-memory).
 **Q: How does this affect bundle size?**
 
 A: result-ts is designed for tree-shaking. Import only what you need -
-basic usage adds ~120 bytes.
+basic usage adds ~107 bytes, full features under 1.3KB.
 
 **Q: Can I mix result-ts with async/await?**
 

--- a/tests/bundle-size.test.ts
+++ b/tests/bundle-size.test.ts
@@ -63,7 +63,7 @@ describe("Bundle Size Tests - README Claims Verification", () => {
 		console.log(`✅ Iter module: ${size} bytes (target: ~800 bytes)`);
 	});
 
-	it("batch module - should match README claim (~291 bytes)", async () => {
+	it("batch module - should match README claim (~1143 bytes)", async () => {
 		const importCode = `
       import { all, analyze } from 'result-ts/batch';
       console.log(all, analyze);
@@ -71,10 +71,10 @@ describe("Bundle Size Tests - README Claims Verification", () => {
 
 		const size = await bundleAndMeasure(importCode);
 		expect(size).toBeLessThan(1300); // Updated: current ~1113 bytes + buffer
-		console.log(`✅ Batch module: ${size} bytes (target: ~291 bytes)`);
+		console.log(`✅ Batch module: ${size} bytes (target: ~1143 bytes)`);
 	});
 
-	it("patterns module - should match README claim (~500 bytes)", async () => {
+	it("patterns module - should match README claim (~1282 bytes)", async () => {
 		const importCode = `
       import { safe, zip } from 'result-ts/patterns';
       console.log(safe, zip);
@@ -82,10 +82,10 @@ describe("Bundle Size Tests - README Claims Verification", () => {
 
 		const size = await bundleAndMeasure(importCode);
 		expect(size).toBeLessThan(1500); // Updated: current ~1252 bytes + buffer
-		console.log(`✅ Patterns module: ${size} bytes (target: ~500 bytes)`);
+		console.log(`✅ Patterns module: ${size} bytes (target: ~1282 bytes)`);
 	});
 
-	it("schema module - should match README claim (~245 bytes excluding Zod)", async () => {
+	it("schema module - should match README claim (~556 bytes excluding Zod)", async () => {
 		const importCode = `
       import { validate } from 'result-ts/schema';
       console.log(validate);
@@ -94,7 +94,7 @@ describe("Bundle Size Tests - README Claims Verification", () => {
 		const size = await bundleAndMeasure(importCode);
 		expect(size).toBeLessThan(600); // 245 bytes target + buffer
 		console.log(
-			`✅ Schema module: ${size} bytes (target: ~245 bytes, excluding Zod)`,
+			`✅ Schema module: ${size} bytes (target: ~556 bytes, excluding Zod)`,
 		);
 	});
 });
@@ -138,17 +138,17 @@ describe("Bundle Size Tests - Architecture Verification", () => {
 			{
 				name: "Array processing",
 				import: `import { all } from 'result-ts/batch'; console.log(all);`,
-				target: 291,
+				target: 1143,
 			},
 			{
 				name: "Advanced patterns",
 				import: `import { safe } from 'result-ts/patterns'; console.log(safe);`,
-				target: 500,
+				target: 1282,
 			},
 			{
 				name: "Validation",
 				import: `import { validate } from 'result-ts/schema'; console.log(validate);`,
-				target: 245,
+				target: 556,
 			},
 		];
 


### PR DESCRIPTION
- Updated README table to reflect actual bundle sizes (1143 bytes, 1282 bytes)
- Updated test descriptions and targets to match README claims
- Fixed discrepancy between claimed and actual bundle sizes

🤖 Generated with [Claude Code](https://claude.ai/code)

docs(release): update bundle sizes